### PR TITLE
AWSLambdaArchitecturesChange 권한을 주기 위한 lambda_arch_change_policy_attachment를 추가합니다.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -84,3 +84,9 @@ resource "aws_iam_role_policy_attachment" "efs_policy_attachment" {
   role = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "lambda_arch_change_policy_attachment" {
+  count = var.attach_lambda_arch_change_policy ? 1 : 0
+  role = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaArchitecturesChange"
+}

--- a/variable.tf
+++ b/variable.tf
@@ -81,3 +81,7 @@ variable "attach_efs_policy" {
   type = bool
   default = false
 }
+variable "attach_lambda_arch_change_policy" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
AWSLambdaArchitecturesChange 권한을 주기 위한 lambda_arch_change_policy_attachment를 추가합니다.

이 권한을 부여한 lambda로 다른 lambda의 아키텍처를 변경시키는 tool를 생성할 계획입니다.

올바르게 추가하였는지 검토 후 merge해주시면 감사하겠습니다.