### PR TITLE
lambda full access policy arn 수정

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy_attachment" "rds_policy_attachment" {
 resource "aws_iam_role_policy_attachment" "lambda_resource_policy_attachment" {
   count = var.attach_lambda_policy ? 1 : 0
   role = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_policy_attachment" {


### PR DESCRIPTION
https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambda_FullAccess.html

```bash
╷
│ Error: attaching IAM Policy (arn:aws:iam::aws:policy/AWSLambdaFullAccess) to IAM Role (lambda_architecture_change_tool-lambda-role): operation error IAM: AttachRolePolicy, https response error StatusCode: 404, RequestID: 234966a1-b9b0-40d7-b6da-3608fb0752d8, NoSuchEntity: Policy arn:aws:iam::aws:policy/AWSLambdaFullAccess does not exist or is not attachable.
│
│   with module.mcp_tool_iac_template.aws_iam_role_policy_attachment.lambda_resource_policy_attachment[0],
│   on .terraform/modules/mcp_tool_iac_template/iam.tf line 70, in resource "aws_iam_role_policy_attachment" "lambda_resource_policy_attachment":
│   70: resource "aws_iam_role_policy_attachment" "lambda_resource_policy_attachment" {
│
╵
```

권한이름이 잘못된 것 같아 수정합니다.

AWSLambdaFullAccess
->
AWSLambda_FullAccess